### PR TITLE
Sm 70 configurar busca de gastos categorizados

### DIFF
--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -110,4 +110,28 @@ export class ExpensesController {
       ...result,
     };
   }
+
+  @Get('by-category')
+  @ApiOperation({ summary: 'Busca despesas por categoria para um usuário' })
+  @ApiQuery({ name: 'userId', required: true, example: 'uuid-do-usuario' })
+  @ApiQuery({ name: 'category', required: true, example: 'alimentação' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Lista de despesas da categoria informada',
+  })
+  async getByCategory(
+    @Query('userId') userId: string,
+    @Query('category') category: string,
+  ) {
+    if (!userId || !category) {
+      throw new BadRequestException('userId e category são obrigatórios');
+    }
+
+    const data = await this.expensesService.getExpensesByCategory(userId, category);
+    return {
+      statusCode: HttpStatus.OK,
+      ...data,
+      message: `Foram encontradas ${data.count} despesas na categoria "${category}"`,
+    };
+  }
 }

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -102,4 +102,19 @@ export class ExpensesService {
     await this.cacheManager.del(`expense:${id}`);
     return { message: 'Despesa removida com sucesso' };
   }
+
+  async getExpensesByCategory(userId: string, category: string) {
+    const expenses = await this.prisma.expense.findMany({
+      where: {
+        userId,
+        category,
+      },
+      orderBy: { date: 'desc' },
+    });
+
+    return {
+      data: expenses,
+      count: expenses.length,
+    };
+  }
 }

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -112,9 +112,12 @@ export class ExpensesService {
       orderBy: { date: 'desc' },
     });
 
+    const totalValue = expenses.reduce((sum, expense) => sum + expense.value, 0);
+
     return {
       data: expenses,
       count: expenses.length,
+      totalValue
     };
   }
 }


### PR DESCRIPTION
Adds support for querying user expenses filtered by category. This endpoint returns all matching expenses and includes a count of the results.